### PR TITLE
Added Pinned category in UI

### DIFF
--- a/templates/category.tpl
+++ b/templates/category.tpl
@@ -22,6 +22,11 @@
 			<span title="{totalPostCount}" class="fw-bold">{humanReadableNumber(totalPostCount)}</span>
 			<span class="text-lowercase fw-normal">[[global:posts]]</span>
 		</span>
+		<!-- New Pinned tab -->
+		<span class="badge text-body border border-gray-300 stats text-xs">
+			<span title="{totalPinnedCount}" class="fw-bold">{humanReadableNumber(totalPinnedCount)}</span>
+			<span class="text-lowercase fw-normal">[[global:pinned]]</span>
+		</span>
 	</div>
 </div>
 


### PR DESCRIPTION
This pull request adds a new section to the Discussions page called "Pinned" which will display all the discussion posts that a user wishes to "pin" to view in a consolidated matter within this page.

Updated the the category.tpl file by adding a new span class and having it as a tab on the given page

Once the backend infrastructure is developed and properly linked, the toggle betwen All Tagged, Recently Replied, and Pinned will be functional and the user can see all their pinned posts in this tab